### PR TITLE
Improve search by ignoring accents and use primary language for terms

### DIFF
--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -17,8 +17,9 @@ module Decidim
         @translations ||= TranslationStore.new(backend_translations)
       end
 
-      # as additional language might not be complete, we also search in the primary language translations to ensure full coverage
-      # Note we assume English is the primary language in Decidim, which won't be changing anytime soon
+      # Additional languages may be incomplete, so searches also include the primary
+      # language translations as a fallback to improve coverage. In Decidim,
+      # English is treated as the primary language for this fallback.
       def primary_terms
         @primary_terms ||= TranslationStore.new(all_translations[:en])
       end

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -23,7 +23,9 @@ module Decidim
       end
 
       def translations_search(search)
-        translations_by_key(search).merge(translations_by_term(search)).merge(primary_terms.by_term(search)).uniq
+        translations_by_key(search)
+          .merge(translations_by_term(search))
+          .merge(primary_terms.by_term(search))
       end
 
       def translations_by_key(search)

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -24,13 +24,14 @@ module Decidim
       end
 
       def translations_search(search)
-        translations_by_key(search)
-          .merge(primary_terms.by_term(search))
-          .merge(translations_by_term(search))
+        merge_search_results(
+          translations.by_key(search).merge(translations.by_term(search)),
+          primary_terms.by_key(search).merge(primary_terms.by_term(search))
+        )
       end
 
       def translations_by_key(search)
-        primary_terms.by_key(search)
+        merge_search_results(translations.by_key(search), primary_terms.by_key(search))
       end
 
       def translations_by_term(search, case_sensitive: false)
@@ -55,6 +56,10 @@ module Decidim
 
       def all_translations
         backend.translations(do_init: true)
+      end
+
+      def merge_search_results(locale_results, primary_results)
+        primary_results.merge(locale_results)
       end
     end
   end

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def all_translations
-        @all_translations ||= I18n.backend.translations(do_init: true)
+        @all_translations ||= backend.translations(do_init: true)
       end
 
       def merge_search_results(locale_results, primary_results)

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -17,12 +17,17 @@ module Decidim
         @translations ||= TranslationStore.new(backend_translations)
       end
 
+      # as additional language might not be complete, we also search in the primary language translations to ensure full coverage
+      def primary_terms
+        @primary_terms ||= TranslationStore.new(all_translations[:en])
+      end
+
       def translations_search(search)
-        translations_by_key(search).merge(translations_by_term(search))
+        translations_by_key(search).merge(translations_by_term(search)).merge(primary_terms.by_term(search)).uniq
       end
 
       def translations_by_key(search)
-        translations.by_key(search)
+        primary_terms.by_key(search)
       end
 
       def translations_by_term(search, case_sensitive: false)
@@ -42,8 +47,11 @@ module Decidim
       end
 
       def backend_translations
-        list = backend.translations(do_init: true)
-        list[locale]
+        all_translations[locale]
+      end
+
+      def all_translations
+        backend.translations(do_init: true)
       end
     end
   end

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -17,22 +17,23 @@ module Decidim
         @translations ||= TranslationStore.new(backend_translations)
       end
 
-      # Additional languages may be incomplete, so searches also include the primary
-      # language translations as a fallback to improve coverage. In Decidim,
-      # English is treated as the primary language for this fallback.
-      def primary_terms
-        @primary_terms ||= TranslationStore.new(all_translations[:en])
+      # Additional languages may be incomplete, so searches also include the
+      # canonical English source translations as a fallback to improve coverage.
+      # In Decidim, English is the upstream source locale and the only locale
+      # guaranteed to contain the full translation key set.
+      def canonical_source_terms
+        @canonical_source_terms ||= TranslationStore.new(all_translations[:en])
       end
 
       def translations_search(search)
         merge_search_results(
           translations.by_key(search).merge(translations.by_term(search)),
-          primary_terms.by_key(search).merge(primary_terms.by_term(search))
+          canonical_source_terms.by_key(search).merge(canonical_source_terms.by_term(search))
         )
       end
 
       def translations_by_key(search)
-        merge_search_results(translations.by_key(search), primary_terms.by_key(search))
+        merge_search_results(translations.by_key(search), canonical_source_terms.by_key(search))
       end
 
       def translations_by_term(search, case_sensitive: false)
@@ -56,7 +57,7 @@ module Decidim
       end
 
       def all_translations
-        backend.translations(do_init: true)
+        @all_translations ||= I18n.backend.translations(do_init: true)
       end
 
       def merge_search_results(locale_results, primary_results)

--- a/lib/decidim/term_customizer/translation_directory.rb
+++ b/lib/decidim/term_customizer/translation_directory.rb
@@ -18,14 +18,15 @@ module Decidim
       end
 
       # as additional language might not be complete, we also search in the primary language translations to ensure full coverage
+      # Note we assume English is the primary language in Decidim, which won't be changing anytime soon
       def primary_terms
         @primary_terms ||= TranslationStore.new(all_translations[:en])
       end
 
       def translations_search(search)
         translations_by_key(search)
-          .merge(translations_by_term(search))
           .merge(primary_terms.by_term(search))
+          .merge(translations_by_term(search))
       end
 
       def translations_by_key(search)

--- a/lib/decidim/term_customizer/translation_store.rb
+++ b/lib/decidim/term_customizer/translation_store.rb
@@ -18,8 +18,10 @@ module Decidim
       end
 
       def by_term(search, case_sensitive: false)
+        normalized_search = case_sensitive ? search : normalize(search).downcase
+
         @values.select do |_key, term|
-          includes_string?(term, search, case_sensitive:)
+          includes_string?(term, normalized_search, case_sensitive:)
         end
       end
 
@@ -32,7 +34,7 @@ module Decidim
       def includes_string?(source, search, case_sensitive: false)
         return source.include?(search) if case_sensitive
 
-        normalize(source).downcase.include?(normalize(search).downcase)
+        normalize(source).downcase.include?(search)
       end
 
       def flat_hash(hash)

--- a/lib/decidim/term_customizer/translation_store.rb
+++ b/lib/decidim/term_customizer/translation_store.rb
@@ -28,7 +28,7 @@ module Decidim
       private
 
       def normalize(str)
-        str.unicode_normalize(:nfd).gsub(/\p{Mn}/, "")
+        str.unicode_normalize(:nfd).gsub(/\p{M}/, "")
       end
 
       def includes_string?(source, search, case_sensitive: false)

--- a/lib/decidim/term_customizer/translation_store.rb
+++ b/lib/decidim/term_customizer/translation_store.rb
@@ -25,10 +25,14 @@ module Decidim
 
       private
 
+      def normalize(str)
+        str.unicode_normalize(:nfd).gsub(/\p{Mn}/, "")
+      end
+
       def includes_string?(source, search, case_sensitive: false)
         return source.include?(search) if case_sensitive
 
-        source.downcase.include?(search.downcase)
+        normalize(source).downcase.include?(normalize(search).downcase)
       end
 
       def flat_hash(hash)

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -115,7 +115,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       )
     end
 
-    it "does not returns the correct translation by term" do
+    it "does not return the correct translation by term" do
       expect(subject.translations_by_term("term customizer")).to eq({})
     end
 

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -60,6 +60,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
     context "when the term contains accents" do
       let(:locale) { :ca }
 
+      # rubocop:disable RSpec/SubjectStub
       before do
         allow(subject).to receive(:all_translations).and_return({
                                                                   en: {
@@ -98,6 +99,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
                                                                 }
                                                               })
     end
+    # rubocop:enable RSpec/SubjectStub
 
     it "does not return any translations by key when using the secondary language backend" do
       expect(subject.translations.by_key("term_customizer")).to eq({})
@@ -129,6 +131,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
   context "when the locale has translations for the same keys as the primary language" do
     let(:locale) { :ca }
 
+    # rubocop:disable RSpec/SubjectStub
     before do
       allow(subject).to receive(:all_translations).and_return({
                                                                 en: {
@@ -152,6 +155,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
                                                                 }
                                                               })
     end
+    # rubocop:enable RSpec/SubjectStub
 
     it "returns the localized value for overlapping keys and falls back to English for missing ones in key searches" do
       expect(subject.translations_by_key("menu.term_customizer")).to eq(

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -115,7 +115,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       )
     end
 
-    it "does not returns the correct translations by term" do
+    it "does not returns the correct translation by term" do
       expect(subject.translations_by_term("term customizer")).to eq({})
     end
 

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -135,7 +135,8 @@ describe Decidim::TermCustomizer::TranslationDirectory do
                                                                   decidim: {
                                                                     term_customizer: {
                                                                       menu: {
-                                                                        term_customizer: "Term customizer"
+                                                                        term_customizer: "Term customizer",
+                                                                        secondary_term: "Secondary term"
                                                                       }
                                                                     }
                                                                   }
@@ -152,15 +153,23 @@ describe Decidim::TermCustomizer::TranslationDirectory do
                                                               })
     end
 
-    it "returns the localized value for key searches" do
-      expect(subject.translations_by_key("term_customizer")).to eq(
+    it "returns the localized value for overlapping keys and falls back to English for missing ones in key searches" do
+      expect(subject.translations_by_key("menu.term_customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Personalitzador de termes"
+      )
+
+      expect(subject.translations_by_key("menu.secondary_term")).to eq(
+        "decidim.term_customizer.menu.secondary_term" => "Secondary term"
       )
     end
 
-    it "prefers the localized value when merging global search results" do
-      expect(subject.translations_search("term_customizer")).to eq(
+    it "prefers the localized value and keeps English fallback when merging global search results" do
+      expect(subject.translations_search("menu.term_customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Personalitzador de termes"
+      )
+
+      expect(subject.translations_search("menu.secondary_term")).to eq(
+        "decidim.term_customizer.menu.secondary_term" => "Secondary term"
       )
     end
   end

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -21,7 +21,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
 
   describe "#translations_search" do
     it "returns correct translations" do
-      expect(subject.translations_search("term customizer")).to eq(
+      expect(subject.translations_search("term customizer").to_h).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
       expect(subject.translations_search("term_customizer").length).to eq(80)
@@ -45,6 +45,82 @@ describe Decidim::TermCustomizer::TranslationDirectory do
 
     it "returns correct translations" do
       expect(subject.translations_by_term("term customizer")).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Term customizer"
+      )
+    end
+  end
+
+  context "when using accented characters in the search" do
+    it "returns correct translations when the search is case insensitive" do
+      expect(subject.translations_search("térm custômizer").to_h).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Term customizer"
+      )
+    end
+
+    context "when the term contains accents" do
+      let(:locale) { :ca }
+
+      before do
+        allow(subject).to receive(:all_translations).and_return({
+                                                                  en: {
+                                                                    decidim: {
+                                                                      term_customizer: {
+                                                                        menu: {
+                                                                          term_customizer: "Term custômizer"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                })
+      end
+
+      it "returns correct translations when the search is case insensitive" do
+        expect(subject.translations_search("térm customizer").to_h).to eq(
+          "decidim.term_customizer.menu.term_customizer" => "Term custômizer"
+        )
+      end
+    end
+  end
+
+  context "when the locale is not present in the translations" do
+    let(:locale) { :ca }
+
+    before do
+      allow(subject).to receive(:all_translations).and_return({
+                                                                en: {
+                                                                  decidim: {
+                                                                    term_customizer: {
+                                                                      menu: {
+                                                                        term_customizer: "Term customizer"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              })
+    end
+
+    it "does not return any translations by key when using the secondary language backend" do
+      expect(subject.translations.by_key("term_customizer")).to eq({})
+    end
+
+    it "return translations by key when using the primary language backend" do
+      expect(subject.primary_terms.by_key("term_customizer")).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Term customizer"
+      )
+    end
+
+    it "still returns the correct translations by key globally" do
+      expect(subject.translations_by_key("term_customizer")).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Term customizer"
+      )
+    end
+
+    it "does not returns the correct translations by term" do
+      expect(subject.translations_by_term("term customizer")).to eq({})
+    end
+
+    it "returns the correct translations by term globally with merged search" do
+      expect(subject.translations_search("term customizer").to_h).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
     end

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -103,7 +103,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       expect(subject.translations.by_key("term_customizer")).to eq({})
     end
 
-    it "return translations by key when using the primary language backend" do
+    it "returns translations by key when using the primary language backend" do
       expect(subject.primary_terms.by_key("term_customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -125,4 +125,43 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       )
     end
   end
+
+  context "when the locale has translations for the same keys as the primary language" do
+    let(:locale) { :ca }
+
+    before do
+      allow(subject).to receive(:all_translations).and_return({
+                                                                en: {
+                                                                  decidim: {
+                                                                    term_customizer: {
+                                                                      menu: {
+                                                                        term_customizer: "Term customizer"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                ca: {
+                                                                  decidim: {
+                                                                    term_customizer: {
+                                                                      menu: {
+                                                                        term_customizer: "Personalitzador de termes"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              })
+    end
+
+    it "returns the localized value for key searches" do
+      expect(subject.translations_by_key("term_customizer")).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Personalitzador de termes"
+      )
+    end
+
+    it "prefers the localized value when merging global search results" do
+      expect(subject.translations_search("term_customizer")).to eq(
+        "decidim.term_customizer.menu.term_customizer" => "Personalitzador de termes"
+      )
+    end
+  end
 end

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -103,8 +103,8 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       expect(subject.translations.by_key("term_customizer")).to eq({})
     end
 
-    it "returns translations by key when using the primary language backend" do
-      expect(subject.primary_terms.by_key("term_customizer")).to eq(
+    it "returns translations by key when using the English source fallback" do
+      expect(subject.canonical_source_terms.by_key("term_customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
     end

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -21,7 +21,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
 
   describe "#translations_search" do
     it "returns correct translations" do
-      expect(subject.translations_search("term customizer").to_h).to eq(
+      expect(subject.translations_search("term customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
       expect(subject.translations_search("term_customizer").length).to eq(80)
@@ -52,7 +52,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
 
   context "when using accented characters in the search" do
     it "returns correct translations when the search is case insensitive" do
-      expect(subject.translations_search("térm custômizer").to_h).to eq(
+      expect(subject.translations_search("térm custômizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
     end
@@ -75,7 +75,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
       end
 
       it "returns correct translations when the search is case insensitive" do
-        expect(subject.translations_search("térm customizer").to_h).to eq(
+        expect(subject.translations_search("térm customizer")).to eq(
           "decidim.term_customizer.menu.term_customizer" => "Term custômizer"
         )
       end
@@ -120,7 +120,7 @@ describe Decidim::TermCustomizer::TranslationDirectory do
     end
 
     it "returns the correct translations by term globally with merged search" do
-      expect(subject.translations_search("term customizer").to_h).to eq(
+      expect(subject.translations_search("term customizer")).to eq(
         "decidim.term_customizer.menu.term_customizer" => "Term customizer"
       )
     end

--- a/spec/lib/decidim/term_customizer/translation_store_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_store_spec.rb
@@ -17,6 +17,10 @@ describe Decidim::TermCustomizer::TranslationStore do
         second_level: {
           third_level: "First second third"
         }
+      },
+      unicode_marks: {
+        spacing_mark: "a\u0903b",
+        enclosing_mark: "a\u20DDb"
       }
     }
   end
@@ -56,6 +60,13 @@ describe Decidim::TermCustomizer::TranslationStore do
       it "matches terms ignoring accents" do
         expect(subject.by_term("öne twô thrèe1").length).to eq(1)
         expect(subject.by_term("fïrst sécond thïrd").length).to eq(1)
+      end
+
+      it "matches terms when the source contains other Unicode mark categories" do
+        expect(subject.by_term("ab")).to include(
+          "unicode_marks.spacing_mark" => "a\u0903b",
+          "unicode_marks.enclosing_mark" => "a\u20DDb"
+        )
       end
 
       it "does not match unrelated terms" do

--- a/spec/lib/decidim/term_customizer/translation_store_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_store_spec.rb
@@ -52,6 +52,17 @@ describe Decidim::TermCustomizer::TranslationStore do
   end
 
   describe "#by_term" do
+    context "when searching with accented characters" do
+      it "matches terms ignoring accents" do
+        expect(subject.by_term("öne twô thrèe1").length).to eq(1)
+        expect(subject.by_term("fïrst sécond thïrd").length).to eq(1)
+      end
+
+      it "does not match unrelated terms" do
+        expect(subject.by_term("öne thrèe").length).to eq(0)
+      end
+    end
+
     context "when case insensitive" do
       it "returns a specific transation for specific term" do
         expect(subject.by_term("One two three1").length).to eq(1)


### PR DESCRIPTION
  * Translation search now merges locale results with canonical English fallback for broader coverage.
  * Search matching normalizes Unicode (diacritics/accents) and is case-insensitive for more accurate matches.
