### PR TITLE
Accept uppercase keys & harden validations againts invalid yaml

### DIFF
--- a/app/forms/decidim/term_customizer/admin/translation_form.rb
+++ b/app/forms/decidim/term_customizer/admin/translation_form.rb
@@ -17,6 +17,7 @@ module Decidim
         validates :key, format: { with: %r{\A([A-Za-z0-9_/?-]+\.)*[A-Za-z0-9_/?-]+\z} }, unless: -> { key.blank? }
         validates :value, translatable_presence: true
         validate :key_uniqueness
+        validate :key_hierarchy_uniqueness, unless: -> { key.blank? }
 
         def map_model(model)
           self.value = Decidim::TermCustomizer::Translation.where(
@@ -32,6 +33,20 @@ module Decidim
             locale: I18n.locale,
             key:
           ).where.not(id:).exists?
+        end
+
+        def key_hierarchy_uniqueness
+          return unless translation_set
+
+          scope = translation_set.translations.where(locale: I18n.locale).where.not(id:)
+          key_parts = key.split(".")
+          ancestors = key_parts.each_index.map { |index| key_parts[0..index].join(".") }[0...-1]
+          escaped_key = ActiveRecord::Base.sanitize_sql_like(key)
+
+          has_ancestor = ancestors.any? && scope.exists?(key: ancestors)
+          has_descendant = scope.exists?(["key LIKE ?", "#{escaped_key}.%"])
+
+          errors.add(:key, :invalid) if has_ancestor || has_descendant
         end
       end
     end

--- a/app/forms/decidim/term_customizer/admin/translation_form.rb
+++ b/app/forms/decidim/term_customizer/admin/translation_form.rb
@@ -14,7 +14,7 @@ module Decidim
         translatable_attribute :value, String
 
         validates :key, presence: true
-        validates :key, format: { with: %r{\A([a-z0-9_/?-]+\.)*[a-z0-9_/?-]+\z} }, unless: -> { key.blank? }
+        validates :key, format: { with: %r{\A([A-Za-z0-9_/?-]+\.)*[A-Za-z0-9_/?-]+\z} }, unless: -> { key.blank? }
         validates :value, translatable_presence: true
         validate :key_uniqueness
 

--- a/app/models/decidim/term_customizer/translation.rb
+++ b/app/models/decidim/term_customizer/translation.rb
@@ -10,7 +10,7 @@ module Decidim
 
       validates :locale, presence: true
       validates :key, presence: true
-      validates :key, format: { with: %r{\A([a-z0-9_/?-]+\.)*[a-z0-9_/?-]+\z} }, unless: -> { key.blank? }
+      validates :key, format: { with: %r{\A([A-Za-z0-9_/?-]+\.)*[A-Za-z0-9_/?-]+\z} }, unless: -> { key.blank? }
       validates :key, uniqueness: { scope: [:translation_set, :locale] }, unless: -> { key.blank? }
 
       class << self

--- a/lib/decidim/term_customizer/loader.rb
+++ b/lib/decidim/term_customizer/loader.rb
@@ -47,9 +47,16 @@ module Decidim
 
               current = final_hash
               keyparts.each do |key|
-                current[key.to_sym] ||= {}
-                current = current[key.to_sym]
+                key = key.to_sym
+
+                # A translation key cannot be both a leaf and a branch.
+                # If a scalar exists but we need to descend, prefer the branch.
+                current[key] = {} unless current[key].is_a?(Hash)
+                current = current[key]
               end
+
+              # Ignore leaf value if this key already has nested children.
+              next if current[lastkey].is_a?(Hash)
 
               current[lastkey] = tr.value
             end

--- a/spec/forms/decidim/term_customizer/admin/translation_form_spec.rb
+++ b/spec/forms/decidim/term_customizer/admin/translation_form_spec.rb
@@ -33,6 +33,36 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
+        context "when key has an existing parent key" do
+          let(:key) { "custom.pae.services.1" }
+
+          before do
+            create(:translation, translation_set:, locale:, key: "custom.pae.services")
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when key has an existing child key" do
+          let(:key) { "custom.pae.services" }
+
+          before do
+            create(:translation, translation_set:, locale:, key: "custom.pae.services.1")
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when conflicting key exists in another locale" do
+          let(:key) { "custom.pae.services" }
+
+          before do
+            create(:translation, translation_set:, locale: :fi, key: "custom.pae.services.1")
+          end
+
+          it { is_expected.to be_valid }
+        end
+
         it_behaves_like "translation validatable"
       end
     end

--- a/spec/lib/decidim/term_customizer/loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/loader_spec.rb
@@ -65,6 +65,45 @@ describe Decidim::TermCustomizer::Loader do
 
       subject.translations_hash
     end
+
+    context "when a key exists as both leaf and branch" do
+      let(:conflicting_keys) do
+        {
+          custom: {
+            pae: {
+              services: {
+                "1": "another text",
+                "2": "yet another text"
+              }
+            }
+          }
+        }
+      end
+
+      it "builds a valid nested tree when parent key is inserted first" do
+        translations = [
+          create(:translation, locale: :en, key: "custom.pae.services", value: "something"),
+          create(:translation, locale: :en, key: "custom.pae.services.1", value: "another text"),
+          create(:translation, locale: :en, key: "custom.pae.services.2", value: "yet another text")
+        ]
+
+        allow(resolver).to receive(:translations).and_return(translations)
+
+        expect(subject.translations_hash).to include(en: conflicting_keys)
+      end
+
+      it "builds a valid nested tree when parent key is inserted last" do
+        translations = [
+          create(:translation, locale: :en, key: "custom.pae.services.1", value: "another text"),
+          create(:translation, locale: :en, key: "custom.pae.services.2", value: "yet another text"),
+          create(:translation, locale: :en, key: "custom.pae.services", value: "something")
+        ]
+
+        allow(resolver).to receive(:translations).and_return(translations)
+
+        expect(subject.translations_hash).to include(en: conflicting_keys)
+      end
+    end
   end
 
   describe "#clear_cache" do

--- a/spec/shared/translation_validator_examples.rb
+++ b/spec/shared/translation_validator_examples.rb
@@ -31,6 +31,12 @@ shared_examples "translation validatable" do
 
       it { is_expected.to be_valid }
     end
+
+    context "with uppercase characters" do
+      let(:key) { "Translation.Key" }
+
+      it { is_expected.to be_valid }
+    end
   end
 
   context "when key is empty" do
@@ -42,12 +48,6 @@ shared_examples "translation validatable" do
   context "when key is incorrect format" do
     context "with spaces" do
       let(:key) { "incorrect format key" }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context "with uppercase characters" do
-      let(:key) { "Translation.Key" }
 
       it { is_expected.not_to be_valid }
     end
@@ -77,7 +77,7 @@ shared_examples "translation validatable" do
     end
 
     context "with a long key repeating similar strings" do
-      let(:key) { "test.test.test.test.test.test.test.test.testA" }
+      let(:key) { "test.test.test.test.test.test.test.test.test." }
 
       it "does not run exponentially long" do
         limit = 3.seconds.from_now


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated translation key validation to accept uppercase letters in addition to lowercase letters, enabling greater flexibility in key naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->