### PR TITLE
Fix clear cache in notifications maily digest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,4 @@ RSpec/DescribeClass:
   Exclude:
     - spec/i18n_spec.rb
     - "spec/system/**/*"
+    - "spec/lib/**/*"

--- a/lib/decidim/term_customizer.rb
+++ b/lib/decidim/term_customizer.rb
@@ -37,7 +37,13 @@ module Decidim
     end
 
     class << self
-      attr_accessor :loader
+      def loader
+        Thread.current.thread_variable_get(:term_customizer_loader)
+      end
+
+      def loader=(loader)
+        Thread.current.thread_variable_set(:term_customizer_loader, loader)
+      end
     end
   end
 end

--- a/lib/decidim/term_customizer/engine.rb
+++ b/lib/decidim/term_customizer/engine.rb
@@ -33,6 +33,10 @@ module Decidim
           customizer_backend.reload!
         end
 
+        ActiveSupport::Notifications.subscribe "process_action.action_controller" do
+          TermCustomizer.loader = nil
+        end
+
         # The jobs are generally run in different context than the controllers
         # which causes the term customizations not to be active. During the
         # jobs, only the organization and global context translations are loaded
@@ -61,6 +65,10 @@ module Decidim
 
           # Force the backend to reload the translations for the job
           customizer_backend.reload!
+        end
+
+        ActiveSupport::Notifications.subscribe "perform.active_job" do
+          TermCustomizer.loader = nil
         end
       end
     end

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -20,17 +20,10 @@ module Decidim
         end
 
         def initialized?
-          !@translations.nil?
-        end
-
-        # Clean up translations hash on reload!
-        def reload!
-          @translations = nil
-          super
+          !TermCustomizer.loader.nil?
         end
 
         def translations
-          return @translations if @translations
           return {} unless TermCustomizer.loader
 
           @translations = TermCustomizer.loader.translations_hash

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -30,7 +30,6 @@ module Decidim
         end
 
         def translations
-          return @translations if @translations
           return {} unless TermCustomizer.loader
 
           @translations = TermCustomizer.loader.translations_hash

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -30,6 +30,7 @@ module Decidim
         end
 
         def translations
+          return @translations if @translations
           return {} unless TermCustomizer.loader
 
           @translations = TermCustomizer.loader.translations_hash

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -20,7 +20,13 @@ module Decidim
         end
 
         def initialized?
-          !TermCustomizer.loader.nil?
+          !@translations.nil?
+        end
+
+        # Clean up translations hash on reload!
+        def reload!
+          @translations = nil
+          super
         end
 
         def translations

--- a/spec/lib/decidim/term_customizer/term_customizer_loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/term_customizer_loader_spec.rb
@@ -11,12 +11,6 @@ describe "Decidim::TermCustomizer.loader" do
       thread1_loader = nil
       thread2_loader = nil
 
-      begin
-        Concurrent::CyclicBarrier.new(2)
-      rescue StandardError
-        nil
-      end
-
       t1 = Thread.new do
         Decidim::TermCustomizer.loader = loader_org1
         sleep 0.05

--- a/spec/lib/decidim/term_customizer/term_customizer_loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/term_customizer_loader_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Decidim::TermCustomizer.loader" do
+  describe ".loader" do
+    it "is isolated per thread" do
+      loader_org1 = double("loader_org1")
+      loader_org2 = double("loader_org2")
+
+      thread1_loader = nil
+      thread2_loader = nil
+
+      begin
+        Concurrent::CyclicBarrier.new(2)
+      rescue StandardError
+        nil
+      end
+
+      t1 = Thread.new do
+        Decidim::TermCustomizer.loader = loader_org1
+        sleep 0.05
+        thread1_loader = Decidim::TermCustomizer.loader
+      end
+
+      t2 = Thread.new do
+        sleep 0.02
+        Decidim::TermCustomizer.loader = loader_org2
+        thread2_loader = Decidim::TermCustomizer.loader
+      end
+
+      t1.join
+      t2.join
+
+      expect(thread1_loader).to eq(loader_org1)
+      expect(thread2_loader).to eq(loader_org2)
+    end
+  end
+
+  describe "Decidim::TermCustomizer::I18nBackend" do
+    let(:backend) { Decidim::TermCustomizer::I18nBackend.new }
+
+    let(:translations_org1) { { en: { decidim: { test_key: "Org 1 translation" } } } }
+    let(:translations_org2) { { en: { decidim: { test_key: "Org 2 translation" } } } }
+
+    it "does not bleed translations between concurrent threads" do
+      loader_org1 = double("loader_org1", translations_hash: translations_org1)
+      loader_org2 = double("loader_org2", translations_hash: translations_org2)
+
+      result_thread1 = nil
+      result_thread2 = nil
+
+      t1 = Thread.new do
+        Decidim::TermCustomizer.loader = loader_org1
+        sleep 0.05
+        result_thread1 = backend.translations
+      end
+
+      t2 = Thread.new do
+        sleep 0.02
+        Decidim::TermCustomizer.loader = loader_org2
+        result_thread2 = backend.translations
+      end
+
+      t1.join
+      t2.join
+
+      expect(result_thread1).to eq(translations_org1)
+      expect(result_thread2).to eq(translations_org2)
+    end
+  end
+end


### PR DESCRIPTION
🎩 What? Why?
 Fix the bug where translations are not always applied after clear cache, especially in Decidiamo emails such as daily digest and newsletter, requiring the button to be clicked again.

📷 Screenshots


♥️ Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cross-thread/background-job leakage in the term customizer by isolating and clearing per-request/job loader state; translations now safely fall back when no loader is present.

* **Tests**
  * Added concurrency tests to verify per-thread isolation and translation safety.

* **Chores**
  * Updated lint configuration to exclude additional test directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->