### PR TITLE
Fix translation sets list pagination and ordering

### DIFF
--- a/app/controllers/concerns/decidim/term_customizer/admin/filterable.rb
+++ b/app/controllers/concerns/decidim/term_customizer/admin/filterable.rb
@@ -21,6 +21,35 @@ module Decidim
             ).distinct
           end
 
+          def filtered_collection
+            paginate(
+              Decidim::TermCustomizer::TranslationSet
+                .where(id: query.result.select(:id).reorder(nil))
+                .order(translated_name_order, id: :asc)
+            )
+          end
+
+          def translated_name_order
+            locales = [I18n.locale.to_s, current_organization.default_locale.to_s].uniq
+
+            Arel::Nodes::NamedFunction.new(
+              "COALESCE",
+              locales.map { |locale| blank_as_null(translated_name(locale)) }
+            )
+          end
+
+          def translated_name(locale)
+            Arel::Nodes::InfixOperation.new(
+              "->>",
+              Decidim::TermCustomizer::TranslationSet.arel_table[:name],
+              Arel::Nodes.build_quoted(locale)
+            )
+          end
+
+          def blank_as_null(node)
+            Arel::Nodes::NamedFunction.new("NULLIF", [node, Arel::Nodes.build_quoted("")])
+          end
+
           def search_field_predicate
             :search_text_or_translations_key_or_translations_value_cont
           end

--- a/app/views/decidim/term_customizer/admin/translation_sets/index.html.erb
+++ b/app/views/decidim/term_customizer/admin/translation_sets/index.html.erb
@@ -19,8 +19,8 @@
     <%= render "search" %>
   </div>
 
-  <div class="table-scroll mt-16">
-    <% if @sets.count > 0 %>
+  <% if @sets.count > 0 %>
+    <div class="table-scroll mt-16">
       <table class="table-list">
         <thead>
           <tr>
@@ -81,11 +81,11 @@
             <% end %>
           </tbody>
         </table>
-      </div>
-    <% else %>
-      <div class="flex flex-col items-center mt-4">
-        <%= t ".no_records_html", new_set_link: new_translation_set_path, button_name: t("decidim.term_customizer.admin.actions.new_translation_set") %>
-      </div>
-    <% end %>
-  </div>
+    </div>
+    <%= decidim_paginate @sets %>
+  <% else %>
+    <div class="flex flex-col items-center mt-4">
+      <%= t ".no_records_html", new_set_link: new_translation_set_path, button_name: t("decidim.term_customizer.admin.actions.new_translation_set") %>
+    </div>
+  <% end %>
 </div>

--- a/spec/controllers/decidim/term_customizer/admin/translation_sets_controller_spec.rb
+++ b/spec/controllers/decidim/term_customizer/admin/translation_sets_controller_spec.rb
@@ -58,6 +58,54 @@ module Decidim
             expect(assigns(:sets)).not_to include(non_matching_set)
           end
         end
+
+        context "when there are more sets than the page size" do
+          before { create_list(:translation_set, 16, organization:) }
+
+          it "shows the first page and links to the next one" do
+            get :index
+            expect(assigns(:sets).count).to eq(Decidim::Paginable::OPTIONS.first)
+            expect(response.body).to include("page=2")
+          end
+
+          it "shows the remaining sets in the next page" do
+            get :index, params: { page: 2 }
+            expect(assigns(:sets).count).to eq(1)
+          end
+        end
+
+        context "when the sets are not created in alphabetical order" do
+          let!(:last_set) { create(:translation_set, organization:, name: { en: "Zzz set" }) }
+          let!(:first_set) { create(:translation_set, organization:, name: { en: "Aaa set" }) }
+
+          it "sorts them by their translated name" do
+            get :index
+            ids = assigns(:sets).map(&:id)
+            expect(ids.index(first_set.id)).to be < ids.index(last_set.id)
+          end
+        end
+
+        context "when a set has no name in the current locale" do
+          let!(:localized_set) { create(:translation_set, organization:, name: { en: "Aaa set", ca: "Zzz conjunt" }) }
+          let!(:fallback_set) { create(:translation_set, organization:, name: { en: "Bbb set" }) }
+
+          it "sorts it by the name rendered in the list" do
+            get :index, params: { locale: "ca" }
+            ids = assigns(:sets).map(&:id)
+            expect(ids.index(fallback_set.id)).to be < ids.index(localized_set.id)
+          end
+        end
+
+        context "when two sets share the same name" do
+          let!(:first_set) { create(:translation_set, organization:, name: { en: "Same name" }) }
+          let!(:last_set) { create(:translation_set, organization:, name: { en: "Same name" }) }
+
+          it "keeps them in a stable order" do
+            get :index
+            ids = assigns(:sets).map(&:id)
+            expect(ids.select { |id| [first_set.id, last_set.id].include?(id) }).to eq([first_set.id, last_set.id])
+          end
+        end
       end
 
       describe "GET new" do


### PR DESCRIPTION
While testing the upgrade to decidim v0.32 (#13) in Decidim Barcelona. We detected the pagination element was missing and we were unable to see more than 25 elements. This PR includes a commit from the upgrade with the fix for this issue
